### PR TITLE
Switch calendar view to defaultDate value

### DIFF
--- a/demos/default-date.html
+++ b/demos/default-date.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Hello Week - Javascript Calendar</title>
+    <meta content="IE=edge" http-equiv="X-UA-Compatible">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" rel="stylesheet">
+    <link href="../dist/helloweek.min.css" rel="stylesheet">
+    <link href="css/demo.css" rel="stylesheet">
+</head>
+<body>
+    <header class="header">
+        <nav class="nav">
+            <h1 class="title">Hello Week <span class="tag">v1.4.0</span></h1>
+            <ul>
+                <li><a href="../index.html">Home</a></li>
+                <li><a href="documentation.html">Documentation</a></li>
+                <li><a href="" class="is-active">Demos</a></li>
+                <li><a href="https://codeload.github.com/maurovieirareis/hello-week/zip/master" title="Download" download="">Download</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main>
+        <section class="section">
+            <div class="container">
+                <div class="hello-week">
+                    <div class="flex-line space-between">
+                        <div>
+                            <button class="btn btn-default btn-today">Today</button>
+                            <button class="btn btn-default btn-clear">Clear</button>
+                        </div>
+                        <div class="form__field">
+                            <input id="switch-1" type="checkbox" value="1" name="switch[]" class="form__switch btn-range">
+                            <label for="switch-1" class="form__label">Range</label>
+                        </div>
+                    </div>
+                    <div class="hello-week__header">
+                        <button class="btn btn-prev">◀</button>
+                        <div class="hello-week__label"></div>
+                        <button class="btn btn-next">▶</button>
+                    </div>
+                </div>
+                <div class="days-highlight">
+                    <ul class="days">
+                        <li class="days__item">
+                            <span style="--color-item: #6495ed;"></span>Summer Holidays
+                        </li>
+                        <li class="days__item">
+                            <span style="--color-item: #f08080;"></span>John Doe Birthday
+                        </li>
+                    </ul>
+                </div>
+                <div class="demo-exemplo">
+                    <p><strong>Today:</strong> </p>
+                    <ul class="demo-today"><span>n/a</span></ul>
+
+                    <p><strong>Last Picked Day:</strong></p>
+                    <ul class="demo-last"><li>n/a</li></ul>
+
+                    <p><strong>Picked Days:</strong></p>
+                    <ul class="demo-picked"><li>n/a</li></ul>
+                </div>
+                <div class="highlight">
+                    <script src="https://gist.github.com/maurovieirareis/9a4b801a0dcf6bf43e240aeefd654b92.js"></script>
+                </div>
+            </div>
+        </section>
+    </main>
+    <footer class="footer">
+        <div class="container">
+            <p>Follow me on:
+                <a href="https://github.com/maurovieirareis/" title="GitHub">GitHub</a> and
+                <a href="https://twitter.com/mauroreisvieira/" title="Twitter">Twitter</a>
+            </p>
+        </div>
+    </footer>
+
+    <script src="../dist/helloweek.min.js" type="text/javascript"></script>
+    <script>
+        const prev = document.querySelector('.btn-prev');
+        const next = document.querySelector('.btn-next');
+        const today = document.querySelector('.btn-today');
+        const range = document.querySelector('.btn-range');
+        const clear = document.querySelector('.btn-clear');
+        const currentDay = document.querySelector('.demo-today');
+        const picked = document.querySelector('.demo-picked');
+        const last = document.querySelector('.demo-last');
+
+        function updateInfo() {
+            if (this.getToday()) {
+                currentDay.innerHTML = '';
+                var li = document.createElement('li');
+                li.innerHTML = this.getToday();
+                currentDay.appendChild(li);
+            }
+
+            if (this.selectedDays.length > 0) {
+                picked.innerHTML = '';
+                for (days of this.selectedDays) {
+                    var li = document.createElement('li');
+                    li.innerHTML = days;
+                    picked.appendChild(li);
+                }
+            } else {
+                picked.innerHTML = '<li>n/a</li>';
+            }
+
+            if (this.lastSelectedDay) {
+                last.innerHTML = '';
+                var li = document.createElement('li');
+                li.innerHTML = this.lastSelectedDay;
+                last.appendChild(li);
+            }
+        }
+
+        function updateView() {
+            picked.innerHTML = '<li>n/a</li>';
+        }
+
+        const myCalendar = new HelloWeek({
+            langFolder: '../dist/langs/',
+            lang: 'en',
+            format: 'DD-MM-YYYY',
+                todayHighlight: true,
+                disableDates: false,
+                disablePastDays: false,
+                disabledDaysOfWeek: [0],
+                defaultDate: '2018-09-08:00:00', // Don't forget to add hours and seconds HH:SS
+                weekStart: 0,
+                range: false,
+                nav: false,
+                onLoad: updateInfo,
+                onChange: updateInfo,
+                onSelect: updateInfo,
+                onClear: updateView,
+            });
+
+        prev.addEventListener('click', () => myCalendar.prev());
+        next.addEventListener('click', () => myCalendar.next());
+        today.addEventListener('click', () => myCalendar.today());
+        clear.addEventListener('click', () => myCalendar.clear());
+        range.addEventListener('click', () => myCalendar.setRange());
+    </script>
+</body>
+</html>

--- a/src/scripts/hello-week.ts
+++ b/src/scripts/hello-week.ts
@@ -55,8 +55,15 @@ export class HelloWeek {
         this.week = this.creatHTMLElement(HelloWeek.CSS_CLASSES.WEEK, this.selector);
         this.month = this.creatHTMLElement(HelloWeek.CSS_CLASSES.MONTH, this.selector);
 
-        this.date = new Date();
-        this.currentDay = new Date();
+
+        // Check if defaultDate is present so we change the calendar view to that specific date
+        if (this.options.defaultDate) {
+            this.date = new Date(this.options.defaultDate);
+            this.currentDay = new Date(this.options.defaultDate);
+        } else {
+            this.date = new Date();
+            this.currentDay = new Date();
+        }
 
         this.readFile(this.options.langFolder + this.options.lang + '.json', (text: any) => {
             this.langs = JSON.parse(text);


### PR DESCRIPTION
This PR allows the date picker to change the initial month according to the defaultDate value (only if it exists).

If we don't provide the `defaultDate` value it is going to take the `new Date()` value.

![image](https://user-images.githubusercontent.com/2782816/42540525-626d0242-8464-11e8-93d9-73dfdf7e49cd.png)
In this example the defaultDate value is set to: `'2018-09-08:00:00'`
**Don't forget to add the hours & seconds to avoid issues when creating the `Date` object** 
### This was intentionally added because if the user wants to see the initial date (`defaultDate`) when showing/opening the calendar he/she won't require to click on the prev/next arrows until the `defaultDate` is visible