### PR TITLE
Update selected-days.html

### DIFF
--- a/docs/v2/demos/selected-days.html
+++ b/docs/v2/demos/selected-days.html
@@ -12,15 +12,22 @@
 
         <script type="module">
             import HelloWeek from './scripts/hello.week.min.js';
+          
+            const date = new Date();
+            const currentYear = date.getFullYear();
+            let currentMonth = date.getMonth();
+            currentMonth = currentMonth < 10 ? '0' + currentMonth : currentMonth;
+          
+            const daysSelected = [
+              `${currentYear}-${currentMonth}-20`,
+              `${currentYear}-${currentMonth}-21`,
+              `${currentYear}-${currentMonth}-22`,
+              `${currentYear}-${currentMonth}-25`,
+            ];
             new HelloWeek({
                 selector: '.calendar',
                 langFolder: './langs/',
-                daysSelected: [
-                    '2020-01-10',
-                    '2020-02-12',
-                    '2020-12-13',
-                    '2020-12-25',
-                ],
+                daysSelected,
                 multiplePick: true,
             });
         </script>

--- a/docs/v2/demos/selected-days.html
+++ b/docs/v2/demos/selected-days.html
@@ -15,7 +15,7 @@
           
             const date = new Date();
             const currentYear = date.getFullYear();
-            let currentMonth = date.getMonth();
+            let currentMonth = date.getMonth() + 1;
             currentMonth = currentMonth < 10 ? '0' + currentMonth : currentMonth;
           
             const daysSelected = [

--- a/docs/v2/demos/selected-days.html
+++ b/docs/v2/demos/selected-days.html
@@ -16,7 +16,7 @@
             const date = new Date();
             const currentYear = date.getFullYear();
             let currentMonth = date.getMonth() + 1;
-            currentMonth = currentMonth < 10 ? '0' + currentMonth : currentMonth;
+            currentMonth.toString().padStart(2, 0);
           
             const daysSelected = [
               `${currentYear}-${currentMonth}-20`,


### PR DESCRIPTION
Selected days example page shows old date, so user must click many times to go to desired month.  I made a small fix to ensure that the example is immediately visible.